### PR TITLE
Fix Deception rogue planet settings

### DIFF
--- a/Miscs/SettingPatches.cfg
+++ b/Miscs/SettingPatches.cfg
@@ -1,0 +1,25 @@
+// Deception as rogue planet
+@Kopernicus:HAS[@CelestialHarmonySettings:HAS[#DeceptRogue[?rue]]]:AFTER[CelestialHarmony]
+{
+    @Body[Deception]
+    {
+        @Orbit
+        {
+            @semiMajorAxis = 71783382278867.12
+            @eccentricity = 0.0000001
+            %mode = OFF
+        }
+    }
+}
+
+@Kopernicus:HAS[@CelestialHarmonySettings:HAS[#DeceptionWH[?rue]]]:FOR[CelestialHarmony]
+{
+    @Body[WHG414]
+    {
+        @Orbit
+        {
+            @referenceBody = Deception
+            @semiMajorAxis = 16000000
+        }
+    }
+}


### PR DESCRIPTION
changed FOR to AFTER for the patch to be properly applied and eccentricity to 0.0000001, otherwise Deception won't move at all